### PR TITLE
Send events to OctoPrint Event Manager

### DIFF
--- a/octoprint_schedule_reboot/__init__.py
+++ b/octoprint_schedule_reboot/__init__.py
@@ -4,64 +4,28 @@ from __future__ import absolute_import
 from time import sleep
 from threading import Thread
 import os
-
 import octoprint.plugin
+import flask
+from octoprint.events import eventManager, Events
 
-class Schedule_rebootPlugin(octoprint.plugin.SettingsPlugin,
-                            octoprint.plugin.AssetPlugin,
-                            octoprint.plugin.SimpleApiPlugin,
-                            octoprint.plugin.TemplatePlugin):
+Events.EVENT_MESSAGE = "ScheduleReboot"
 
-    ##~~ SettingsPlugin mixin
 
-    def get_settings_defaults(self):
-        return dict(
-            # put your plugin's default settings here
-        )
+class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
 
-    ##~~ AssetPlugin mixin
+    def __init__(self):
+        self.remaining = None
 
-    def get_assets(self):
-        # Define your plugin's asset files to automatically include in the
-        # core UI here.
-        return dict(
-            #js=["js/schedule_reboot.js"],
-            #css=["css/schedule_reboot.css"],
-            #less=["less/schedule_reboot.less"]
-        )
-
-    ##~~ Softwareupdate hook
-
-    def get_update_information(self):
-        # Define the configuration for your plugin to use with the Software Update
-        # Plugin here. See https://github.com/foosel/OctoPrint/wiki/Plugin:-Software-Update
-        # for details.
-        return dict(
-            schedule_reboot=dict(
-                displayName="Schedule Reboot",
-                displayVersion=self._plugin_version,
-
-                # version check: github repository
-                type="github_commit",
-                user="voxel8",
-                repo="OctoPrint-Schedule-Reboot",
-                #current=self._plugin_version,
-
-                # update method: pip
-                pip="https://github.com/voxel8/OctoPrint-Schedule-Reboot/archive/{target_version}.zip"
-            )
-        )
-
-    ##~~ SimpleApiPlugin mixin
+    # ~~ SimpleApiPlugin mixin
 
     def get_api_commands(self):
         return dict(
             schedule_reboot=[],
             cancel=[],
+            reboot_now=[],
         )
 
     def on_api_command(self, command, data):
-
         if command == "schedule_reboot":
             self._logger.info("Scheduling reboot...")
             if not self.printer_is_printing():
@@ -76,6 +40,15 @@ class Schedule_rebootPlugin(octoprint.plugin.SettingsPlugin,
             self._cancel_reboot = True
             self.schedule_reboot(7200)
 
+        elif command == "reboot_now":
+            self._logger.info("Reboot called immediately.")
+            os.system('sudo reboot -f')
+
+    def on_api_get(self, request):
+        payload = {'duration': self.remaining}
+        eventManager().fire(Events.EVENT_MESSAGE, payload)
+        return flask.jsonify(remaining=self.remaining)
+
     #########################
 
     def printer_is_printing(self):
@@ -88,6 +61,8 @@ class Schedule_rebootPlugin(octoprint.plugin.SettingsPlugin,
         self._reboot_thread = Thread(target=self._reboot_worker,
                                      args=(secs_from_now,))
         self._reboot_thread.start()
+        payload = {'duration': secs_from_now}
+        eventManager().fire(Events.EVENT_MESSAGE, payload)
 
     def schedule_reboot(self, secs_from_now):
         """ Initiate a reboot in the future,
@@ -97,24 +72,47 @@ class Schedule_rebootPlugin(octoprint.plugin.SettingsPlugin,
         self._future_reboot_thread.start()
 
     def _reboot_worker(self, secs_from_now):
-        remaining = secs_from_now
-        while (not self._cancel_reboot) and remaining > 0:
-            remaining -= 1
+        self.remaining = secs_from_now
+        while (not self._cancel_reboot) and self.remaining > 0:
+            self.remaining -= 1
             sleep(1)
         if not self._cancel_reboot:
-            os.system('sudo reboot now')
+            os.system('sudo reboot -f')
         else:
+            self.remaining = None
             self._logger.info("Reboot thread aborted")
 
     def _future_reboot(self, secs_from_now):
         sleep(secs_from_now)
         self.initiate_reboot(60)
 
+    # ~~ Softwareupdate hook
+
+    def get_update_information(self):
+        # Define the configuration for your plugin to use with the Software Update
+        # Plugin here. See https://github.com/foosel/OctoPrint/wiki/Plugin:-Software-Update
+        # for details.
+        return dict(
+            schedule_reboot=dict(
+                displayName="Schedule Reboot",
+                displayVersion=self._plugin_version,
+
+                # version check: github repository
+                type="github_commit",
+                user="voxel8",
+                repo="OctoPrint-Schedule-Reboot",
+                # current=self._plugin_version,
+
+                # update method: pip
+                pip="https://github.com/voxel8/OctoPrint-Schedule-Reboot/archive/{target_version}.zip"
+            )
+        )
 
 # If you want your plugin to be registered within OctoPrint under a different name than what you defined in setup.py
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "Schedule Reboot"
+
 
 def __plugin_load__():
     global __plugin_implementation__
@@ -124,4 +122,3 @@ def __plugin_load__():
     __plugin_hooks__ = {
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
     }
-

--- a/octoprint_schedule_reboot/__init__.py
+++ b/octoprint_schedule_reboot/__init__.py
@@ -42,7 +42,7 @@ class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
 
         elif command == "reboot_now":
             self._logger.info("Reboot called immediately.")
-            os.system('sudo reboot -f')
+            os.system('sudo reboot')
 
     def on_api_get(self, request):
         payload = {'duration': self.remaining}
@@ -77,7 +77,7 @@ class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
             self.remaining -= 1
             sleep(1)
         if not self._cancel_reboot:
-            os.system('sudo reboot -f')
+            os.system('sudo reboot')
         else:
             self.remaining = None
             self._logger.info("Reboot thread aborted")

--- a/octoprint_schedule_reboot/__init__.py
+++ b/octoprint_schedule_reboot/__init__.py
@@ -23,6 +23,7 @@ class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
             schedule_reboot=[],
             cancel=[],
             reboot_now=[],
+            trigger_status=[],
         )
 
     def on_api_command(self, command, data):
@@ -44,10 +45,9 @@ class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
             self._logger.info("Reboot called immediately.")
             os.system('sudo reboot')
 
-    def on_api_get(self, request):
-        payload = {'duration': self.remaining}
-        eventManager().fire(Events.EVENT_MESSAGE, payload)
-        return flask.jsonify(remaining=self.remaining)
+        elif command == "trigger_status":
+            payload = {'duration': self.remaining}
+            eventManager().fire(Events.EVENT_MESSAGE, payload)
 
     #########################
 

--- a/octoprint_schedule_reboot/__init__.py
+++ b/octoprint_schedule_reboot/__init__.py
@@ -1,22 +1,19 @@
 # coding=utf-8
 from __future__ import absolute_import
 
+import os
 from time import sleep
 from threading import Thread
-import os
 import octoprint.plugin
-import flask
 from octoprint.events import eventManager, Events
 
-Events.EVENT_MESSAGE = "ScheduleReboot"
+Events.SCHEDULE_REBOOT_EVENT = "ScheduleReboot"
 
 
 class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
 
     def __init__(self):
         self.remaining = None
-
-    # ~~ SimpleApiPlugin mixin
 
     def get_api_commands(self):
         return dict(
@@ -27,29 +24,32 @@ class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
         )
 
     def on_api_command(self, command, data):
+        log_msg = None
         if command == "schedule_reboot":
             self._logger.info("Scheduling reboot...")
             if not self.printer_is_printing():
-                self._logger.info("Printer not in use, rebooting in 60 seconds")
+                log_msg = "Printer not in use, rebooting in 60 seconds"
+                self._logger.info(log_msg)
                 self.initiate_reboot(60)
             else:
-                self._logger.info("Printer in use, will try again in 60 minutes")
+                log_msg = "Printer in use, will try again in 60 minutes"
+                self._logger.info(log_msg)
                 self.schedule_reboot(7200)
 
         elif command == "cancel":
-            self._logger.info("Scheduled reboot cancelled, will try again in 60 minutes")
+            log_msg = "Scheduled reboot cancelled, trying again in 60 minutes"
+            self._logger.info(log_msg)
             self._cancel_reboot = True
             self.schedule_reboot(7200)
 
         elif command == "reboot_now":
-            self._logger.info("Reboot called immediately.")
+            log_msg = "Reboot called immediately"
+            self._logger.info(log_msg)
             os.system('sudo reboot')
 
         elif command == "trigger_status":
             payload = {'duration': self.remaining}
-            eventManager().fire(Events.EVENT_MESSAGE, payload)
-
-    #########################
+            eventManager().fire(Events.SCHEDULE_REBOOT_EVENT, payload)
 
     def printer_is_printing(self):
         return self._printer.is_printing() or self._printer.is_paused()
@@ -62,7 +62,7 @@ class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
                                      args=(secs_from_now,))
         self._reboot_thread.start()
         payload = {'duration': secs_from_now}
-        eventManager().fire(Events.EVENT_MESSAGE, payload)
+        eventManager().fire(Events.SCHEDULE_REBOOT_EVENT, payload)
 
     def schedule_reboot(self, secs_from_now):
         """ Initiate a reboot in the future,
@@ -86,31 +86,6 @@ class Schedule_rebootPlugin(octoprint.plugin.SimpleApiPlugin):
         sleep(secs_from_now)
         self.initiate_reboot(60)
 
-    # ~~ Softwareupdate hook
-
-    def get_update_information(self):
-        # Define the configuration for your plugin to use with the Software Update
-        # Plugin here. See https://github.com/foosel/OctoPrint/wiki/Plugin:-Software-Update
-        # for details.
-        return dict(
-            schedule_reboot=dict(
-                displayName="Schedule Reboot",
-                displayVersion=self._plugin_version,
-
-                # version check: github repository
-                type="github_commit",
-                user="voxel8",
-                repo="OctoPrint-Schedule-Reboot",
-                # current=self._plugin_version,
-
-                # update method: pip
-                pip="https://github.com/voxel8/OctoPrint-Schedule-Reboot/archive/{target_version}.zip"
-            )
-        )
-
-# If you want your plugin to be registered within OctoPrint under a different name than what you defined in setup.py
-# ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
-# can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "Schedule Reboot"
 
 
@@ -119,6 +94,7 @@ def __plugin_load__():
     __plugin_implementation__ = Schedule_rebootPlugin()
 
     global __plugin_hooks__
+    update_hook = "octoprint.plugin.softwareupdate.check_config"
     __plugin_hooks__ = {
-        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+        update_hook: __plugin_implementation__.get_update_information
     }


### PR DESCRIPTION
This emits events when schedule reboot is initiated so we can display the overlay on printer_ui. Also, the time remaining in the scheduled reboot is kept so if printer_ui ever loses a socket connection, it can grab the latest number and display the overlay accordingly.

A get response will trigger a new event to be sent rather than implementing more complicated logic into printer_ui.

Removed unused plugin mixins.